### PR TITLE
setup.py: Remove install_requires of "distribute"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         ],
 
     install_requires=[
-        'distribute',
         'funcsigs>=0.4',
         ],
     tests_require=[


### PR DESCRIPTION
Distribute is no longer maintained. Setuptools is back and you probably don't have to put it in `install_requires`.