### PR TITLE
setup.py: Remove "distribute" from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         ],
 
     install_requires=[
-        'distribute',
         'funcsigs>=0.4',
         ],
     tests_require=[


### PR DESCRIPTION
Distribute was merged back into setuptools and deprecated.

But I also don't think having `install_requires` include `distribute` or `setuptools` does anything, because it's too late. If anything, it should go in `setup_requires` though it is very rare for folks to do this either. The `from setuptools import setup` is usually all that is needed.