### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 `backports.inspect`_
 ====================
 
-.. image:: https://pypip.in/version/backports.inspect/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/backports.inspect.svg?style=flat
     :target: https://pypi.python.org/pypi/backports.inspect/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20backports-inspect))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `backports-inspect`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.